### PR TITLE
Update webpack-dev-server to v2.4.2

### DIFF
--- a/generators/_init-web/templates/package.tmpl.json
+++ b/generators/_init-web/templates/package.tmpl.json
@@ -60,6 +60,6 @@
     "typescript": "2.2.0",
     "url-loader": "0.5.7",
     "webpack": "2.2.1",
-    "webpack-dev-server": "2.3.0"
+    "webpack-dev-server": "2.4.2"
   }
 }

--- a/generators/_init-web/templates/plain/webpack.config.js
+++ b/generators/_init-web/templates/plain/webpack.config.js
@@ -164,6 +164,7 @@ function generateWebpack(options) {
       loaders: webpackloaders.slice()
     },
     devServer: {
+      ignored: '/node_modules/',
       proxy: {
         '/api/*': {
           target: 'http://localhost:9000',

--- a/generators/_init-web/templates/plain/webpack.config.js
+++ b/generators/_init-web/templates/plain/webpack.config.js
@@ -164,7 +164,9 @@ function generateWebpack(options) {
       loaders: webpackloaders.slice()
     },
     devServer: {
-      ignored: '/node_modules/',
+      watchOptions: {
+        ignored: '/node_modules/'
+      },
       proxy: {
         '/api/*': {
           target: 'http://localhost:9000',


### PR DESCRIPTION
With v2.4.2 it's possible to use the `ignored` property on `/node_modules/`, which decreases the CPU usage on Windows dramatically.

See
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.4.2
* https://webpack.js.org/configuration/watch/#watchoptions-ignored
* https://github.com/webpack/webpack/issues/701#issuecomment-236354970