### PR TITLE
Include arguments of failed commands in error logging

### DIFF
--- a/generators/setup-workspace/index.js
+++ b/generators/setup-workspace/index.js
@@ -154,7 +154,7 @@ class Generator extends Base {
     const r = this._spawn(cmd, argline, cwd);
     if (failed(r)) {
       this.log(r);
-      return this._abort('failed: ' + cmd + ' - status code: ' + r.status);
+      return this._abort('failed: ' + cmd + ' - status code: ' + r.status + ' args: ' + argline);
     }
     return Promise.resolve(cmd);
   }


### PR DESCRIPTION
To see which command failed.
Now:
`Error: failed: git - status code: 128`
Then:
`Error: failed: git - status code: 128 args: clone,git@github.com:foobar/repo.git`
