### PR TITLE
Remove `tags` property from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ jobs:
     working_directory: ~/phovea
     docker:
       - image: circleci/node:8-browsers
-    tags:
-      - /v\d+.\d+.\d+.*/
     steps:
       - checkout
       - restore_cache:

--- a/generators/_init-hybrid/templates/plain/.circleci/config.yml
+++ b/generators/_init-hybrid/templates/plain/.circleci/config.yml
@@ -4,8 +4,6 @@ jobs:
     working_directory: ~/phovea
     docker:
       - image: caleydo/phovea_circleci_python:v1.0
-    tags:
-      - /v\d+.\d+.\d+.*/
     steps:
       - checkout
       - run:

--- a/generators/_init-python/templates/plain/.circleci/config.yml
+++ b/generators/_init-python/templates/plain/.circleci/config.yml
@@ -4,8 +4,6 @@ jobs:
     working_directory: ~/phovea
     docker:
       - image: caleydo/phovea_circleci_python:v1.0
-    tags:
-      - /v\d+.\d+.\d+.*/
     steps:
       - checkout
       - run:

--- a/generators/_init-web/templates/plain/.circleci/config.yml
+++ b/generators/_init-web/templates/plain/.circleci/config.yml
@@ -4,8 +4,6 @@ jobs:
     working_directory: ~/phovea
     docker:
       - image: circleci/node:8-browsers
-    tags:
-      - /v\d+.\d+.\d+.*/
     steps:
       - checkout
       - restore_cache:

--- a/generators/init-product/templates/plain/.circleci/config.yml
+++ b/generators/init-product/templates/plain/.circleci/config.yml
@@ -5,8 +5,6 @@ jobs:
     docker:
       - image: caleydo/phovea_circleci_python:v2.0
       - image: docker:17.05.0-ce-git
-    tags:
-      - /v\d+.\d+.\d+.*/
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
Closes #220

### Summary

* Remove the deprecated `tags` property on root level from the CircleCI config