### PR TITLE
Replace deprecated `fs.exists` with recommended `fs.existsSync`

### DIFF
--- a/generators/_init-python/index.js
+++ b/generators/_init-python/index.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const Base = require('yeoman-generator');
 const {writeTemplates, patchPackageJSON, stringifyAble, useDevVersion} = require('../../utils');
 const {parseRequirements} = require('../../utils/pip');
+const fs = require('fs');
 
 const known = () => require('../../utils/known');
 
@@ -107,7 +108,7 @@ class Generator extends Base {
     this.fs.write(this.destinationPath('docker_packages.txt'), deps.dockerPackages.join('\n'));
 
     // don't overwrite existing registry file
-    if (!this.fs.exists(this.destinationPath(config.name.toLowerCase() + '/__init__.py'))) {
+    if (!fs.existsSync(this.destinationPath(config.name.toLowerCase() + '/__init__.py'))) {
       this.fs.copyTpl(this.templatePath('__init__.tmpl.py'), this.destinationPath(config.name.toLowerCase() + '/__init__.py'), stringifyAble(config));
     }
     this.fs.copy(this.templatePath('_gitignore'), this.destinationPath('.gitignore'));

--- a/generators/_init-web/index.js
+++ b/generators/_init-web/index.js
@@ -2,6 +2,7 @@
 const _ = require('lodash');
 const Base = require('yeoman-generator');
 const {writeTemplates, patchPackageJSON, stringifyAble, useDevVersion} = require('../../utils');
+const fs = require('fs');
 
 const known = () => require('../../utils/known');
 
@@ -134,7 +135,7 @@ class Generator extends Base {
     this.fs.copy(this.templatePath('_gitignore'), this.destinationPath('.gitignore'));
     writeTemplates.call(this, config);
     // don't overwrite existing registry file
-    if (!this.fs.exists(this.destinationPath('phovea.js'))) {
+    if (!fs.existsSync(this.destinationPath('phovea.js'))) {
       this.fs.copyTpl(this.templatePath('phovea.tmpl.js'), this.destinationPath('phovea.js'), stringifyAble(config));
     }
   }

--- a/generators/add-extension/index.js
+++ b/generators/add-extension/index.js
@@ -4,6 +4,7 @@ const Base = require('yeoman-generator');
 const plugins = require('../../utils/types').plugin;
 const stringifyAble = require('../../utils').stringifyAble;
 const path = require('path');
+const fs = require('fs');
 
 function toJSONFromText(text) {
   const r = {};
@@ -107,9 +108,9 @@ class Generator extends Base {
     this.fs.write(file, new_);
 
     const target = this.destinationPath(`src/${d.module}${d.module.includes('.') ? '' : '.ts'}`);
-    if (absFile.startsWith('.') && !this.fs.exists(target)) {
+    if (absFile.startsWith('.') && !fs.existsSync(target)) {
       let source = this.templatePath(`${d.type}.tmpl.ts`);
-      if (!this.fs.exists(source)) {
+      if (!fs.existsSync(source)) {
         source = this.templatePath('template.tmpl.ts');
       }
       const config = this._getModuleConfig(target);
@@ -126,9 +127,9 @@ class Generator extends Base {
     this.fs.write(file, new_);
 
     const target = this.destinationPath(`${name}/${d.module}.py`);
-    if (!this.fs.exists(target)) {
+    if (!fs.existsSync(target)) {
       let source = this.templatePath(`${d.type}.tmpl.py`);
-      if (!this.fs.exists(source)) {
+      if (!fs.existsSync(source)) {
         source = this.templatePath('template.tmpl.py');
       }
       const config = this._getModuleConfig(target);

--- a/generators/init-product/index.js
+++ b/generators/init-product/index.js
@@ -5,6 +5,7 @@ const Base = require('yeoman-generator');
 const {writeTemplates, patchPackageJSON} = require('../../utils');
 const {simplifyRepoUrl} = require('../../utils/repo');
 const chalk = require('chalk');
+const fs = require('fs');
 
 const isRequired = (v) => v.toString().length > 0;
 
@@ -125,7 +126,7 @@ class Generator extends Base {
     writeTemplates.call(this, config);
     this.fs.copy(this.templatePath('_gitignore'), this.destinationPath('.gitignore'));
     // don't overwrite existing registry file
-    if (!this.fs.exists(this.destinationPath('phovea_product.json'))) {
+    if (!fs.existsSync(this.destinationPath('phovea_product.json'))) {
       this.fs.writeJSON(this.destinationPath('phovea_product.json'), this.services);
     }
   }

--- a/generators/init-slib/index.js
+++ b/generators/init-slib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const BasePluginGenerator = require('../../utils').BasePython;
+const fs = require('fs');
 
 class PluginGenerator extends BasePluginGenerator {
 
@@ -13,7 +14,7 @@ class PluginGenerator extends BasePluginGenerator {
 
   writing() {
     super.writing();
-    if (!this.fs.exists(this.destinationPath(this.config.get('name') + '/config.json'))) {
+    if (!fs.existsSync(this.destinationPath(this.config.get('name') + '/config.json'))) {
       this.fs.writeJSON(this.destinationPath(this.config.get('name') + '/config.json'), {});
     }
   }

--- a/generators/install/index.js
+++ b/generators/install/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const Base = require('yeoman-generator');
 const path = require('path');
+const fs = require('fs');
 
 function toPluginRepo(url, useSSH) {
   const match = url.match(/(github:)?([\w\d-_]+\/)?([\w\d-_]+)(#.+)?/);
@@ -69,7 +70,7 @@ class Generator extends Base {
   default() {
     this.plugin = this.options.for;
 
-    if (this.fs.exists(this.destinationPath('../.yo-rc-workspace.json'))) {
+    if (fs.existsSync(this.destinationPath('../.yo-rc-workspace.json'))) {
       // we are in a workspace
       this.plugin = path.basename(this.destinationRoot());
       this.log('switch to workspace for install dependencies but keep ' + this.plugin, 'in mind');
@@ -102,7 +103,7 @@ class Generator extends Base {
 
   end() {
     const fs = require('fs-extra');
-    if (this.plugin && this.fs.exists(this.destinationPath(`package.json`))) {
+    if (this.plugin && fs.existsSync(this.destinationPath(`package.json`))) {
       // also store the dependency in the plugin
       const child = {dependencies: {}};
       if (this.options.type.startsWith('p')) {

--- a/generators/prepare-release/index.js
+++ b/generators/prepare-release/index.js
@@ -216,7 +216,7 @@ class Generator extends Base {
 
     let p = Promise.resolve(1);
 
-    if (this.fs.exists(`${ctx.cwd}/requirements.txt`)) {
+    if (fs.existsSync(`${ctx.cwd}/requirements.txt`)) {
       ctx.requirements = {};
       const req = parseRequirements(this.fs.read(`${ctx.cwd}/requirements.txt`));
       p = Promise.all(Object.keys(req).map((dep) => {

--- a/generators/update/index.js
+++ b/generators/update/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const Base = require('yeoman-generator');
+const fs = require('fs');
 
 function extractFromReadme(content) {
   const safe = (p) => p ? p[1] : '';
@@ -14,7 +15,7 @@ function extractFromReadme(content) {
 class Generator extends Base {
 
   initializing() {
-    this.isWorkspace = this.fs.exists(this.destinationPath('.yo-rc-workspace.json'));
+    this.isWorkspace = fs.existsSync(this.destinationPath('.yo-rc-workspace.json'));
 
     if (!this.isWorkspace) {
       this._initializingPlugin();

--- a/generators/workspace/index.js
+++ b/generators/workspace/index.js
@@ -5,6 +5,7 @@ const glob = require('glob').sync;
 const chalk = require('chalk');
 const extend = require('lodash').extend;
 const _ = require('lodash');
+const fs = require('fs');
 
 const known = () => require('../../utils/known');
 const writeTemplates = require('../../utils').writeTemplates;
@@ -54,7 +55,7 @@ class Generator extends Base {
 
     // use existing workspace package.json as default
     const pkgPath = this.destinationPath('package.json');
-    if(this.fs.exists(pkgPath)) {
+    if (fs.existsSync(pkgPath)) {
       const pkg = this.fs.readJSON(pkgPath);
       defaultConfig = Object.assign(defaultConfig, {name: pkg.name, description: pkg.description, version: pkg.version});
     }
@@ -268,7 +269,7 @@ class Generator extends Base {
 
       // merge docker-compose
       const dockerFile = (fileName) => {
-        if (!this.fs.exists(this.destinationPath(fileName))) {
+        if (!fs.existsSync(this.destinationPath(fileName))) {
           return {};
         }
         const yaml = require('yamljs');
@@ -405,8 +406,8 @@ class Generator extends Base {
       scripts.start = `cd ${this.props.defaultApp} && npm start`;
     }
 
-    const patchYamlExists = this.fs.exists(this.destinationPath('docker-compose-patch.yaml'));
-    if (patchYamlExists || this.fs.exists(this.destinationPath('docker-compose-patch.yml'))) {
+    const patchYamlExists = fs.existsSync(this.destinationPath('docker-compose-patch.yaml'));
+    if (patchYamlExists || fs.existsSync(this.destinationPath('docker-compose-patch.yml'))) {
       const yaml = require('yamljs');
       const file = this.fs.read(this.destinationPath(patchYamlExists ? 'docker-compose-patch.yaml' : 'docker-compose-patch.yml'));
       const patch = yaml.parse(file);
@@ -421,7 +422,7 @@ class Generator extends Base {
     const config = {};
     config.workspace = path.basename(this.destinationPath());
     config.modules = _.union(this.props.modules, plugins, sdeps.plugins);
-    config.webmodules = plugins.filter((d) => this.fs.exists(this.destinationPath(d + '/phovea_registry.js')));
+    config.webmodules = plugins.filter((d) => fs.existsSync(this.destinationPath(d + '/phovea_registry.js')));
     config.dockerCompose = path.resolve(this.destinationPath('docker-compose.yml'));
     config.wsName = this.options.wsName;
     config.wsDescription = this.options.wsDescription;
@@ -431,7 +432,7 @@ class Generator extends Base {
     // replace the added entries
     patchPackageJSON.call(this, config, [], {devDependencies, dependencies, scripts}, true);
 
-    if (!this.fs.exists(this.destinationPath('config.json'))) {
+    if (!fs.existsSync(this.destinationPath('config.json'))) {
       this.fs.copy(this.templatePath('config.tmpl.json'), this.destinationPath('config.json'));
     }
 
@@ -439,7 +440,7 @@ class Generator extends Base {
     this.fs.write(this.destinationPath('requirements_dev.txt'), sdeps.devRequirements.sort().join('\n'));
     this.fs.write(this.destinationPath('docker_packages.txt'), sdeps.dockerPackages.sort().join('\n'));
 
-    if (this.fs.exists(this.destinationPath('docker_script_patch.sh'))) {
+    if (fs.existsSync(this.destinationPath('docker_script_patch.sh'))) {
       // push patch to the beginning
       sdeps.dockerScripts.unshift(this.fs.read(this.destinationPath('docker_script_patch.sh')));
     }
@@ -447,7 +448,7 @@ class Generator extends Base {
     this.fs.write(this.destinationPath('docker_script.sh'), `#!/usr/bin/env bash\n\n` + sdeps.dockerScripts.join('\n'));
 
     this.fs.copyTpl(this.templatePath('project.tmpl.iml'), this.destinationPath(`.idea/${config.workspace}.iml`), config);
-    if (!this.fs.exists(this.destinationPath(`.idea/workspace.xml`))) {
+    if (!fs.existsSync(this.destinationPath(`.idea/workspace.xml`))) {
       this.fs.copy(this.templatePath('workspace.tmpl.xml'), this.destinationPath(`.idea/workspace.xml`));
     }
   }

--- a/utils/index.js
+++ b/utils/index.js
@@ -3,12 +3,13 @@ const Generator = require('yeoman-generator');
 const {merge, template} = require('lodash');
 const path = require('path');
 const glob = require('glob').sync;
+const fs = require('fs');
 
 function patchPackageJSON(config, unset, extra, replaceExtra) {
   const pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
 
   let pkgPatch;
-  if (this.fs.exists(this.templatePath('package.tmpl.json'))) {
+  if (fs.existsSync(this.templatePath('package.tmpl.json'))) {
     pkgPatch = JSON.parse(template(this.fs.read(this.templatePath('package.tmpl.json')))(config));
   } else {
     pkgPatch = {};
@@ -70,21 +71,17 @@ function writeTemplates(config, withSamples) {
   };
 
   const copy = (prefix) => {
-    this.fs.exists(this.templatePath(prefix + 'plain'), (exists) => {
-      if(exists === false) {
-        return;
-      }
+    if (fs.existsSync(this.templatePath(prefix + 'plain'))) {
       this.fs.copy(this.templatePath(prefix + 'plain/**/*'), this.destinationPath(), includeDot);
-    });
+    }
+
     copyTpl(this.templatePath(prefix + 'processed'), '');
 
     if (config.name) {
-      this.fs.exists(this.templatePath(prefix + 'pluginname_plain'), (exists) => {
-        if(exists === false) {
-          return;
-        }
+      if (fs.existsSync(this.templatePath(prefix + 'pluginname_plain'))) {
         this.fs.copy(this.templatePath(prefix + 'pluginname_plain/**/*'), this.destinationPath(config.name.toLowerCase() + '/'), includeDot);
-      });
+      }
+
       copyTpl(this.templatePath(prefix + 'pluginname_processed'), config.name.toLowerCase() + '/');
     }
   };
@@ -120,7 +117,7 @@ class BaseInitPluginGenerator extends Generator {
 
   readmeAddon() {
     const f = this.templatePath('README.partial.md');
-    if (this.fs.exists(f)) {
+    if (fs.existsSync(f)) {
       return this.fs.read(f);
     }
     return '';
@@ -138,10 +135,10 @@ class BaseInitPluginGenerator extends Generator {
 
   writing() {
     const config = this.config.getAll();
-    if (this.fs.exists(this.templatePath('package.tmpl.json'))) {
+    if (fs.existsSync(this.templatePath('package.tmpl.json'))) {
       this._patchPackageJSON(config);
     }
-    if (this.fs.exists(this.templatePath('_gitignore'))) {
+    if (fs.existsSync(this.templatePath('_gitignore'))) {
       this.fs.copy(this.templatePath('_gitignore'), this.destinationPath('.gitignore'));
     }
 


### PR DESCRIPTION
closes phovea/generator-phovea#227

### Summary

* We were using ` this.fs.exists(path)` which [is deprecated](https://nodejs.org/api/fs.html#fs_fs_exists_path_callback) 
* Behaviour of `this.fs.exists(path) ` from yeoman base class is different from `fs.exists()`
* Fixed `this.fs.exists(this.templatePath('path'))` always returns `false` if path is a directory 
* Fixed wrong `this.fs.exists()` with callback
* Replaced it with the recommended `fs.existsSync(path)` https://stackoverflow.com/questions/4482686/check-synchronously-if-file-directory-exists-in-node-js
