### PR TITLE
Fix wrong file selector for typedoc command

### DIFF
--- a/generators/_init-web/templates/package.tmpl.json
+++ b/generators/_init-web/templates/package.tmpl.json
@@ -13,7 +13,7 @@
   "scripts": {
     "compile": "tsc",
     "lint": "tslint -c tslint.json -p .",
-    "docs": "typedoc --options typedoc.json src/**/.ts",
+    "docs": "typedoc --options typedoc.json src/**.ts",
     "prebuild": "node -e \"process.exit(process.env.PHOVEA_SKIP_TESTS === undefined?1:0)\" || npm run test",
     "pretest": "npm run compile",
     "test": "test ! -d tests || karma start",

--- a/generators/_init-web/templates/package.tmpl.json
+++ b/generators/_init-web/templates/package.tmpl.json
@@ -13,7 +13,7 @@
   "scripts": {
     "compile": "tsc",
     "lint": "tslint -c tslint.json -p . 'src/**/*.ts?(x)' 'tests/**/*.ts?(x)'",
-    "docs": "typedoc --options typedoc.json src/**.ts",
+    "docs": "typedoc --options typedoc.json src/",
     "prebuild": "node -e \"process.exit(process.env.PHOVEA_SKIP_TESTS === undefined?1:0)\" || npm run test",
     "pretest": "npm run compile",
     "test": "test ! -d tests || karma start",


### PR DESCRIPTION
Fixes 252

### Developer Checklist (Definition of Done)

* [x] Descriptive title for this pull request provided (will be used for release notes later)
* [x] All acceptance criteria from the issue are met
* [x] Branch is up-to-date with the branch to be merged with, i.e., develop
* [x] Code is cleaned up and formatted
* [x] Code documentation written
* [x] Unit tests written
* [x] Build is successful
* [x] [Summary of changes](#summary-of-changes) written
* [x] Wiki documentation written
* [x] Assign at least one reviewer
* [x] Assign at least one assignee
* [x] Add type label (e.g., *bug*, *enhancement*) to this pull request
* [x] Add next version label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)


### Summary of changes

* Fixed the file selector and made it equal to the the hybrid template

see https://github.com/phovea/generator-phovea/blob/111c77a25eca14e722c5ef40f10f608270c2faec/generators/_init-hybrid/templates/package.tmpl.json#L17

