### PR TITLE
Fix registration of yo sub-generators in setup-workspace and bui…

### DIFF
--- a/generators/init-product/templates/plain/build.js
+++ b/generators/init-product/templates/plain/build.js
@@ -297,12 +297,13 @@ function yo(generator, options, cwd, args) {
   const yeoman = require('yeoman-environment');
   // call yo internally
   const yeomanEnv = yeoman.createEnv([], {cwd, env}, quiet ? createQuietTerminalAdapter() : undefined);
-  yeomanEnv.register(require.resolve('generator-phovea/generators/' + generator), 'phovea:' + generator);
   const _args = Array.isArray(args) ? args.join(' ') : args || '';
   return new Promise((resolve, reject) => {
     try {
       console.log(cwd, chalk.blue('running yo phovea:' + generator));
-      yeomanEnv.run(`phovea:${generator} ${_args}`, options, resolve);
+      yeomanEnv.lookup(() => {
+        yeomanEnv.run(`phovea:${generator} ${_args}`, options, resolve);
+      });
     } catch (e) {
       console.error('error', e, e.stack);
       reject(e);

--- a/generators/setup-workspace/index.js
+++ b/generators/setup-workspace/index.js
@@ -140,14 +140,15 @@ class Generator extends Base {
     const env = yeoman.createEnv([], {
       cwd: this.cwd
     }, this.env.adapter);
-    env.register(require.resolve('../' + generator), 'phovea:' + generator);
     const _args = Array.isArray(args) ? args.join(' ') : args || '';
     return new Promise((resolve, reject) => {
       try {
         this.log('running yo phovea:' + generator);
-        env.run(`phovea:${generator} ${_args}`, options || {}, () => {
-          // wait a second after running yo to commit the files correctly
-          setTimeout(() => resolve(), 500);
+        env.lookup(() => {
+          env.run(`phovea:${generator} ${_args}`, options || {}, () => {
+            // wait a second after running yo to commit the files correctly
+            setTimeout(() => resolve(), 500);
+          });
         });
       } catch (e) {
         console.error('error', e, e.stack);


### PR DESCRIPTION
Closes phovea/generator-phovea#263

### Developer Checklist (Definition of Done)

* [x] Descriptive title for this pull request provided (will be used for release notes later)
* [ ] All acceptance criteria from the issue are met
* [x] Branch is up-to-date with the branch to be merged with, i.e., develop
* [x] Code is cleaned up and formatted
* [ ] Code documentation written
* [ ] Unit tests written
* [x] Build is successful
* [x] [Summary of changes](#summary-of-changes) written
* [ ] Wiki documentation written
* [x] Assign at least one reviewer
* [ ] Assign at least one assignee
* [ ] Add type label (e.g., *bug*, *enhancement*) to this pull request
* [ ] Add next version label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)


### Summary of changes

* The problem was that we were using `env.register()` to register a subgenerator 
* That doesn't work  when other subgenerators are called within it .
* Replaced `env.register(require.resolve('../' + generator), 'phovea:' + generator);` 

   with 
   ```
    env.lookup(() => {
          env.run(`phovea:${generator} ${_args}`, options || {}, () => {
            // wait a second after running yo to commit the files correctly
            setTimeout(() => resolve(), 500);
          });
         });
   ```
`env.lookup` scans for  all installed generator/subgenerators.

As stated here: https://stackoverflow.com/questions/48680805/run-a-yeoman-sub-generator-using-yeoman-environment

- I tested the command setup-workspace  in generator-phovea v 1.1.1 and v 2.0.1 and they create 
   they create the same files .
- Further testing though is needed  though.