### PR TITLE
Use phovea.ts in `add-extension` subgenerator

### DIFF
--- a/generators/add-extension/index.js
+++ b/generators/add-extension/index.js
@@ -110,10 +110,10 @@ class Generator extends Base {
   }
 
   _injectWebExtension(d) {
-    const file = this.destinationPath('phovea.js');
+    const file = this.destinationPath('src/phovea.ts');
     const old = this.fs.read(file);
     const absFile = d.module.startsWith('~') ? d.module.slice(1) : `./src/${d.module.includes('.') ? d.module.slice(0, d.module.lastIndexOf('.')) : d.module}`;
-    const text = `\n\n  registry.push('${d.type}', '${d.id}', function() { return import('${absFile}'); }, ${d.stringify(d.extras, ' ')});\n  // generator-phovea:end`;
+    const text = `\n\n  registry.push('${d.type}', '${d.id}', function() { return System.import('${absFile}'); }, ${d.stringify(d.extras, ' ')});\n  // generator-phovea:end`;
     const new_ = old.replace('  // generator-phovea:end', text);
     this.fs.write(file, new_);
 

--- a/generators/add-extension/index.js
+++ b/generators/add-extension/index.js
@@ -110,12 +110,13 @@ class Generator extends Base {
   }
 
   _injectWebExtension(d) {
+    const importFunction = fs.existsSync('src/phovea.ts') ? 'System.import' : 'import'; // TODO remove System.import for Typescript case when switching to Webpack 4 (see https://github.com/phovea/generator-phovea/issues/286#issuecomment-566553497)
     const pathToRegistry = fs.existsSync('src/phovea.ts') ? 'src/phovea.ts' : 'phovea.js'; // check if the project has a phovea.ts file in src folder or a phovea.js in plugin root
     const file = this.destinationPath(pathToRegistry);
 
     const old = this.fs.read(file);
     const absFile = d.module.startsWith('~') ? d.module.slice(1) : `./src/${d.module.includes('.') ? d.module.slice(0, d.module.lastIndexOf('.')) : d.module}`;
-    const text = `\n\n  registry.push('${d.type}', '${d.id}', function() { return System.import('${absFile}'); }, ${d.stringify(d.extras, ' ')});\n  // generator-phovea:end`;
+    const text = `\n\n  registry.push('${d.type}', '${d.id}', function() { return ${importFunction}('${absFile}'); }, ${d.stringify(d.extras, ' ')});\n  // generator-phovea:end`;
     const new_ = old.replace('  // generator-phovea:end', text);
     this.fs.write(file, new_);
 

--- a/generators/add-extension/index.js
+++ b/generators/add-extension/index.js
@@ -110,7 +110,7 @@ class Generator extends Base {
   }
 
   _injectWebExtension(d) {
-    const pathToRegistry = fs.existsSync('src/phovea.ts') ? 'src/phovea.ts' : 'phovea.js';//check if the project has a phovea.js or a phovea.ts file
+    const pathToRegistry = fs.existsSync('src/phovea.ts') ? 'src/phovea.ts' : 'phovea.js'; // check if the project has a phovea.ts file in src folder or a phovea.js in plugin root
     const file = this.destinationPath(pathToRegistry);
 
     const old = this.fs.read(file);

--- a/generators/add-extension/index.js
+++ b/generators/add-extension/index.js
@@ -110,7 +110,9 @@ class Generator extends Base {
   }
 
   _injectWebExtension(d) {
-    const file = this.destinationPath('src/phovea.ts');
+    const pathToRegistry = fs.existsSync('src/phovea.ts') ? 'src/phovea.ts' : 'phovea.js';//check if the project has a phovea.js or a phovea.ts file
+    const file = this.destinationPath(pathToRegistry);
+
     const old = this.fs.read(file);
     const absFile = d.module.startsWith('~') ? d.module.slice(1) : `./src/${d.module.includes('.') ? d.module.slice(0, d.module.lastIndexOf('.')) : d.module}`;
     const text = `\n\n  registry.push('${d.type}', '${d.id}', function() { return System.import('${absFile}'); }, ${d.stringify(d.extras, ' ')});\n  // generator-phovea:end`;


### PR DESCRIPTION
Closes phovea/generator-phovea#238



### Summary of changes

* Added support for phovea.ts  for the add-extension  subgenerator 
* Dropped support for phovea.js since most of the repositories have been updated or will be updated to a phovea.ts registry.
* Replaced `import` with` System.import `since that is the one we use in almost all of our repos 
and also it clashes with tsconfig
### General
* The add-extension subgenerator is very dependent on the existence of the comment  `// generator-phovea:end`
in your phovea.ts file .
* If the comment doesn't exist then the subgenerator doesn't function at all.
* As i have noticed in some phovea.ts files the comment doesn't exist.


