### PR TITLE
Add preinstall command to update git dependencies on `npm install`

### DIFF
--- a/generators/_init-hybrid/templates/package.tmpl.json
+++ b/generators/_init-hybrid/templates/package.tmpl.json
@@ -13,6 +13,7 @@
     "docker_packages.txt"
   ],
   "scripts": {
+    "preinstall": "node preinstall",
     "check": "flake8 --exclude=.git,venv,deploy,docs,__pycache__,node_modules",
     "docs:web": "typedoc --options typedoc.json src/**.ts",
     "docs:python": "sphinx-apidoc -o docs -f ./<%-name.toLowerCase()%> && sphinx-build ./docs build/docs",

--- a/generators/_init-hybrid/templates/plain/.circleci/config.yml
+++ b/generators/_init-hybrid/templates/plain/.circleci/config.yml
@@ -25,10 +25,6 @@ jobs:
       - run:
           name: Install npm dependencies
           command: npm install
-      - run:
-          name: Remove npm dependencies installed from git repositories (avoid caching of old commits)
-          command: |
-            (grep -l '._resolved.: .\(git[^:]*\|bitbucket\):' ./node_modules/*/package.json || true) | xargs -r dirname | xargs -r rm -rf
       - save_cache:
           key: deps2-{{ .Branch }}-{{ checksum "package.json" }}
           paths:

--- a/generators/_init-hybrid/templates/plain/.circleci/preinstall.js
+++ b/generators/_init-hybrid/templates/plain/.circleci/preinstall.js
@@ -1,0 +1,103 @@
+const fs = require('fs');
+const fsPromises = fs.promises;
+const { sep } = require('path');
+
+const nodeModulesDir = 'node_modules';
+const packageLockFilename = 'package-lock.json';
+const dependenciesProperty = 'dependencies';
+
+/**
+ * Read a JSON file and return the parsed JSON
+ * @param {string} filename Path to file
+ */
+async function readJSONFile(filename) {
+    try {
+        const data = await fsPromises.readFile(filename, 'utf-8');
+        return JSON.parse(data);
+    }
+    catch(err) {
+        console.log(err.message);
+        process.exit(0); // exit without error
+    }
+}
+
+/**
+ * JSON stringify the given object and write it to the given file
+ * @param {string} filename Path to file
+ * @param {any} jsonObj Object structure
+ */
+async function writeJSONFile(filename, jsonObj) {
+    try {
+        fsPromises.writeFile(filename, JSON.stringify(jsonObj, null, 4), 'utf-8');
+    }
+    catch(err) {
+        console.log(err.message);
+        process.exit(0); // exit without error
+    }
+}
+
+/**
+ * Check if the given property exists on the first level of the given object
+ * @param {any} json JSON object
+ * @param {string} property Name of the property
+ */
+function checkPropertyExists(json, property) {
+    if (!json.hasOwnProperty(property)) {
+        console.log(`No ${property} property found in ${packageLockFilename}.`);
+        process.exit(0); // exit without error
+    }
+    return json;
+}
+
+/**
+ * Filter git dependencies by the presence of the `from` property in the given dependency object.
+ * @param {any} json JSON object
+ * @param {string} property Name of the property
+ * @returns Returns a list of package names
+ */
+function findGitDependencies(dependencies) {
+    // filter git dependencies by the presence of the `from` property
+    const gitDependencies = Object.entries(dependencies).filter((entry) => entry[1].from).map((entry) => entry[0]);
+
+    if(gitDependencies.length === 0) {
+        console.log(`No git dependencies found in ${packageLockFilename}.`);
+        process.exit(0); // exit without error
+    }
+
+    return gitDependencies;
+}
+
+/**
+ * Remove the given package directory from the node_modules directory
+ * @param {string} nodeModulesDir Path to the node_modules directory
+ * @param {string} packageName Package name to remove
+ */
+function removePackage(nodeModulesDir, packageName) {
+    return fsPromises.rmdir(`${nodeModulesDir}${sep}${packageName}`, {recursive: true}) // recursive requires Node.js v12.10+ (see https://nodejs.org/api/fs.html#fs_fspromises_rmdir_path_options)
+        .then(() => {
+            return packageName;
+        })
+        .catch((err) => {
+            console.error(err.message);
+            process.exit(1); // exit with error
+        });
+}
+
+readJSONFile(packageLockFilename)
+    .then((lockJSON) => checkPropertyExists(lockJSON, dependenciesProperty))
+    .then((lockJSON) => {
+        const gitDependencies = findGitDependencies(lockJSON[dependenciesProperty]);
+        console.log(`The following dependencies will be removed from ${nodeModulesDir} and ${packageLockFilename}: `, gitDependencies);
+
+        return Promise.all(gitDependencies.map((dep) => removePackage(nodeModulesDir, dep)))
+            .then((removedPackages) => {
+                removedPackages.forEach((dep) => {
+                    delete lockJSON[dependenciesProperty][dep]; // mutates the lockJSON object!
+                });
+            })
+            .then(() => lockJSON);
+    })
+    .then((newLockJSON) => writeJSONFile(packageLockFilename, newLockJSON))
+    .then(() => {
+        console.log(`${packageLockFilename} was saved successfully!`);
+    });

--- a/generators/_init-web/templates/package.tmpl.json
+++ b/generators/_init-web/templates/package.tmpl.json
@@ -11,6 +11,7 @@
     "node": ">= 12.13"
   },
   "scripts": {
+    "preinstall": "node preinstall",
     "compile": "tsc",
     "lint": "tslint -c tslint.json -p . 'src/**/*.ts?(x)' 'tests/**/*.ts?(x)'",
     "docs": "typedoc --options typedoc.json src/",

--- a/generators/_init-web/templates/plain/.circleci/config.yml
+++ b/generators/_init-web/templates/plain/.circleci/config.yml
@@ -16,10 +16,6 @@ jobs:
       - run:
           name: Install npm dependencies
           command: npm install
-      - run:
-          name: Remove npm dependencies installed from git repositories (avoid caching of old commits)
-          command: |
-            (grep -l '._resolved.: .\(git[^:]*\|bitbucket\):' ./node_modules/*/package.json || true) | xargs -r dirname | xargs -r rm -rf
       - save_cache:
           key: deps1-{{ .Branch }}-{{ checksum "package.json" }}
           paths:

--- a/generators/_init-web/templates/plain/preinstall.js
+++ b/generators/_init-web/templates/plain/preinstall.js
@@ -1,0 +1,103 @@
+const fs = require('fs');
+const fsPromises = fs.promises;
+const { sep } = require('path');
+
+const nodeModulesDir = 'node_modules';
+const packageLockFilename = 'package-lock.json';
+const dependenciesProperty = 'dependencies';
+
+/**
+ * Read a JSON file and return the parsed JSON
+ * @param {string} filename Path to file
+ */
+async function readJSONFile(filename) {
+    try {
+        const data = await fsPromises.readFile(filename, 'utf-8');
+        return JSON.parse(data);
+    }
+    catch(err) {
+        console.log(err.message);
+        process.exit(0); // exit without error
+    }
+}
+
+/**
+ * JSON stringify the given object and write it to the given file
+ * @param {string} filename Path to file
+ * @param {any} jsonObj Object structure
+ */
+async function writeJSONFile(filename, jsonObj) {
+    try {
+        fsPromises.writeFile(filename, JSON.stringify(jsonObj, null, 4), 'utf-8');
+    }
+    catch(err) {
+        console.log(err.message);
+        process.exit(0); // exit without error
+    }
+}
+
+/**
+ * Check if the given property exists on the first level of the given object
+ * @param {any} json JSON object
+ * @param {string} property Name of the property
+ */
+function checkPropertyExists(json, property) {
+    if (!json.hasOwnProperty(property)) {
+        console.log(`No ${property} property found in ${packageLockFilename}.`);
+        process.exit(0); // exit without error
+    }
+    return json;
+}
+
+/**
+ * Filter git dependencies by the presence of the `from` property in the given dependency object.
+ * @param {any} json JSON object
+ * @param {string} property Name of the property
+ * @returns Returns a list of package names
+ */
+function findGitDependencies(dependencies) {
+    // filter git dependencies by the presence of the `from` property
+    const gitDependencies = Object.entries(dependencies).filter((entry) => entry[1].from).map((entry) => entry[0]);
+
+    if(gitDependencies.length === 0) {
+        console.log(`No git dependencies found in ${packageLockFilename}.`);
+        process.exit(0); // exit without error
+    }
+
+    return gitDependencies;
+}
+
+/**
+ * Remove the given package directory from the node_modules directory
+ * @param {string} nodeModulesDir Path to the node_modules directory
+ * @param {string} packageName Package name to remove
+ */
+function removePackage(nodeModulesDir, packageName) {
+    return fsPromises.rmdir(`${nodeModulesDir}${sep}${packageName}`, {recursive: true}) // recursive requires Node.js v12.10+ (see https://nodejs.org/api/fs.html#fs_fspromises_rmdir_path_options)
+        .then(() => {
+            return packageName;
+        })
+        .catch((err) => {
+            console.error(err.message);
+            process.exit(1); // exit with error
+        });
+}
+
+readJSONFile(packageLockFilename)
+    .then((lockJSON) => checkPropertyExists(lockJSON, dependenciesProperty))
+    .then((lockJSON) => {
+        const gitDependencies = findGitDependencies(lockJSON[dependenciesProperty]);
+        console.log(`The following dependencies will be removed from ${nodeModulesDir} and ${packageLockFilename}: `, gitDependencies);
+
+        return Promise.all(gitDependencies.map((dep) => removePackage(nodeModulesDir, dep)))
+            .then((removedPackages) => {
+                removedPackages.forEach((dep) => {
+                    delete lockJSON[dependenciesProperty][dep]; // mutates the lockJSON object!
+                });
+            })
+            .then(() => lockJSON);
+    })
+    .then((newLockJSON) => writeJSONFile(packageLockFilename, newLockJSON))
+    .then(() => {
+        console.log(`${packageLockFilename} was saved successfully!`);
+    });

--- a/generators/workspace/templates/package.tmpl.json
+++ b/generators/workspace/templates/package.tmpl.json
@@ -14,6 +14,7 @@
     "node": ">= 12.13"
   },
   "scripts": {
+    "preinstall": "node preinstall",
     "compile": "tsc",
     "lint": "tslint -c tslint.json -p .",
     "prebuild": "npm run test",

--- a/generators/workspace/templates/plain/preinstall.js
+++ b/generators/workspace/templates/plain/preinstall.js
@@ -1,0 +1,103 @@
+const fs = require('fs');
+const fsPromises = fs.promises;
+const { sep } = require('path');
+
+const nodeModulesDir = 'node_modules';
+const packageLockFilename = 'package-lock.json';
+const dependenciesProperty = 'dependencies';
+
+/**
+ * Read a JSON file and return the parsed JSON
+ * @param {string} filename Path to file
+ */
+async function readJSONFile(filename) {
+    try {
+        const data = await fsPromises.readFile(filename, 'utf-8');
+        return JSON.parse(data);
+    }
+    catch(err) {
+        console.log(err.message);
+        process.exit(0); // exit without error
+    }
+}
+
+/**
+ * JSON stringify the given object and write it to the given file
+ * @param {string} filename Path to file
+ * @param {any} jsonObj Object structure
+ */
+async function writeJSONFile(filename, jsonObj) {
+    try {
+        fsPromises.writeFile(filename, JSON.stringify(jsonObj, null, 4), 'utf-8');
+    }
+    catch(err) {
+        console.log(err.message);
+        process.exit(0); // exit without error
+    }
+}
+
+/**
+ * Check if the given property exists on the first level of the given object
+ * @param {any} json JSON object
+ * @param {string} property Name of the property
+ */
+function checkPropertyExists(json, property) {
+    if (!json.hasOwnProperty(property)) {
+        console.log(`No ${property} property found in ${packageLockFilename}.`);
+        process.exit(0); // exit without error
+    }
+    return json;
+}
+
+/**
+ * Filter git dependencies by the presence of the `from` property in the given dependency object.
+ * @param {any} json JSON object
+ * @param {string} property Name of the property
+ * @returns Returns a list of package names
+ */
+function findGitDependencies(dependencies) {
+    // filter git dependencies by the presence of the `from` property
+    const gitDependencies = Object.entries(dependencies).filter((entry) => entry[1].from).map((entry) => entry[0]);
+
+    if(gitDependencies.length === 0) {
+        console.log(`No git dependencies found in ${packageLockFilename}.`);
+        process.exit(0); // exit without error
+    }
+
+    return gitDependencies;
+}
+
+/**
+ * Remove the given package directory from the node_modules directory
+ * @param {string} nodeModulesDir Path to the node_modules directory
+ * @param {string} packageName Package name to remove
+ */
+function removePackage(nodeModulesDir, packageName) {
+    return fsPromises.rmdir(`${nodeModulesDir}${sep}${packageName}`, {recursive: true}) // recursive requires Node.js v12.10+ (see https://nodejs.org/api/fs.html#fs_fspromises_rmdir_path_options)
+        .then(() => {
+            return packageName;
+        })
+        .catch((err) => {
+            console.error(err.message);
+            process.exit(1); // exit with error
+        });
+}
+
+readJSONFile(packageLockFilename)
+    .then((lockJSON) => checkPropertyExists(lockJSON, dependenciesProperty))
+    .then((lockJSON) => {
+        const gitDependencies = findGitDependencies(lockJSON[dependenciesProperty]);
+        console.log(`The following dependencies will be removed from ${nodeModulesDir} and ${packageLockFilename}: `, gitDependencies);
+
+        return Promise.all(gitDependencies.map((dep) => removePackage(nodeModulesDir, dep)))
+            .then((removedPackages) => {
+                removedPackages.forEach((dep) => {
+                    delete lockJSON[dependenciesProperty][dep]; // mutates the lockJSON object!
+                });
+            })
+            .then(() => lockJSON);
+    })
+    .then((newLockJSON) => writeJSONFile(packageLockFilename, newLockJSON))
+    .then(() => {
+        console.log(`${packageLockFilename} was saved successfully!`);
+    });


### PR DESCRIPTION
Closes #295

### Developer Checklist (Definition of Done)

* [x] Descriptive title for this pull request provided (will be used for release notes later)
* [x] All acceptance criteria from the issue are met
* [x] Branch is up-to-date with the branch to be merged with, i.e., develop
* [x] Code is cleaned up and formatted
* [x] Code documentation written
* [ ] Unit tests written
* [x] Build is successful
* [x] [Summary of changes](#summary-of-changes) written
* [x] Wiki documentation written
* [x] Assign at least one reviewer
* [x] Assign at least one assignee
* [x] Add type label (e.g., *bug*, *enhancement*) to this pull request
* [ ] Add next version label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)


### Summary of changes

The preinstall script looks for github dependencies in package-lock.json.
Found packages are removed from the node_modules folder and the package-lock.json.
Afterwards `npm install` clones the most recent commits of the github dependencies.

### Screenshots

Using the same setup as described in #295. `npm install` updates all dependencies to most recent commit.

![grafik](https://user-images.githubusercontent.com/5851088/71737270-806cd200-2e53-11ea-916f-fe36c7e71bd5.png)

