### PR TITLE
Revert bundled css filename from `[name]` to `style` in webpack.config.js

### DIFF
--- a/generators/_init-web/templates/plain/webpack.config.js
+++ b/generators/_init-web/templates/plain/webpack.config.js
@@ -280,7 +280,7 @@ function generateWebpack(options) {
   if (!options.bundle || options.isApp) {
     // extract the included css file to own file
     const p = new ExtractTextPlugin({
-      filename: (options.isApp || options.moduleBundle ? '[name]' : pkg.name) + (options.min && !options.nosuffix ? '.min' : '') + '.css',
+      filename: (options.isApp || options.moduleBundle ? 'style' : pkg.name) + (options.min && !options.nosuffix ? '.min' : '') + '.css',
       allChunks: true // there seems to be a bug in dynamically loaded chunk styles are not loaded, workaround: extract all styles from all chunks
     });
     base.plugins.push(p);


### PR DESCRIPTION
Closes #299

### Developer Checklist (Definition of Done)

* [ ] Descriptive title for this pull request provided (will be used for release notes later)
* [ ] All acceptance criteria from the issue are met
* [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
* [ ] Code is cleaned up and formatted
* [ ] Code documentation written
* [ ] Unit tests written
* [ ] Build is successful
* [ ] [Summary of changes](#summary-of-changes) written
* [ ] Wiki documentation written
* [ ] Assign at least one reviewer
* [ ] Assign at least one assignee
* [ ] Add type label (e.g., *bug*, *enhancement*) to this pull request
* [ ] Add next version label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)


### Summary of changes

* Replace bundled css filename `[name]` with `style` in webpack.config.js


### Background information

* `[name]` is replaced with the key of the entry point defined in _.yo-rc.json_ (e.g., [ordino/.yo-rc.json](https://github.com/Caleydo/ordino/blob/e095b2030b77a711e05c8e0f7c438f65ab97c49f/.yo-rc.json#L52))
* _style.css_ is referenced in [phovea_ui/src/template/_head.html](https://github.com/phovea/phovea_ui/blob/980efd61f0867f1656ab0e7f066819461096a8b3/src/template/_head.html#L4)
* All css chunks are bundled into one single css file (and not _common.css_ and _app.css_); see comment in second line:
   https://github.com/phovea/generator-phovea/blob/c591d8bfd061e53eb4969d398736ce8e52a9a9b4/generators/_init-web/templates/plain/webpack.config.js#L283-L284
