### PR TITLE
Add additional compiler options to webpack.config.json

### DIFF
--- a/generators/_init-web/templates/plain/webpack.config.js
+++ b/generators/_init-web/templates/plain/webpack.config.js
@@ -56,8 +56,8 @@ const tsLoaderDev = [
       happyPackMode: true, // IMPORTANT! use happyPackMode mode to speed-up compilation and reduce errors reported to webpack,
       compilerOptions: {
         target: 'es6',
-        "jsx": "react",
-        "jsxFactory": "h",
+        jsx: 'react',
+        jsxFactory: 'h',
       }
     }
   }

--- a/generators/_init-web/templates/plain/webpack.config.js
+++ b/generators/_init-web/templates/plain/webpack.config.js
@@ -55,7 +55,9 @@ const tsLoaderDev = [
     options: {
       happyPackMode: true, // IMPORTANT! use happyPackMode mode to speed-up compilation and reduce errors reported to webpack,
       compilerOptions: {
-        target: 'es6'
+        target: 'es6',
+        "jsx": "react",
+        "jsxFactory": "h",
       }
     }
   }


### PR DESCRIPTION
Closes phovea/generator-phovea#271


### Summary of changes

Added the compiler flags 

```
      compilerOptions: {
        "target": "es6",
        "jsx": "react",
        "jsxFactory": "h",
      }

```