### PR TITLE
Additional entries to gitignore templates

### DIFF
--- a/generators/_init-hybrid/templates/_gitignore
+++ b/generators/_init-hybrid/templates/_gitignore
@@ -4,7 +4,6 @@
 /build/
 /dist/
 *.egg-info/
-*.egg
 *.py[cod]
 __pycache__/
 *.so
@@ -14,6 +13,9 @@ __pycache__/
 *.pyc
 *.swp
 *.lock
+/.awcache
+/local_cache/*
+/data/*
 # due to using tox and pytest
 .tox
 .cache

--- a/generators/_init-hybrid/templates/_gitignore
+++ b/generators/_init-hybrid/templates/_gitignore
@@ -15,7 +15,6 @@ __pycache__/
 *.lock
 /.awcache
 /local_cache/*
-/data/*
 # due to using tox and pytest
 .tox
 .cache

--- a/generators/_init-python/templates/_gitignore
+++ b/generators/_init-python/templates/_gitignore
@@ -16,7 +16,6 @@ __pycache__/
 *.lock
 /.awcache
 /local_cache/*
-/data/*
 # due to using tox and pytest
 .tox
 .cache

--- a/generators/_init-python/templates/_gitignore
+++ b/generators/_init-python/templates/_gitignore
@@ -14,6 +14,9 @@ __pycache__/
 *.pyc
 *.swp
 *.lock
+/.awcache
+/local_cache/*
+/data/*
 # due to using tox and pytest
 .tox
 .cache

--- a/generators/_init-web/templates/_gitignore
+++ b/generators/_init-web/templates/_gitignore
@@ -9,3 +9,4 @@ node_modules/
 *.css
 *.log
 /.cache-loader
+/data/*

--- a/generators/_init-web/templates/_gitignore
+++ b/generators/_init-web/templates/_gitignore
@@ -9,4 +9,3 @@ node_modules/
 *.css
 *.log
 /.cache-loader
-/data/*


### PR DESCRIPTION


Closes phovea/generator-phovea#272


### Summary of changes

- Added  `/data/*` entry  to the web plugin  gitignore
- Added

```
 /.awcache
/local_cache/*
/data/*
```
and removed  `*.egg*` entry  from the hybrid and python plugin  gitignore