### PR TITLE
Escape backslash in branch name and add repo tag in config.yml

### DIFF
--- a/generators/init-product/templates/plain/.circleci/config.yml
+++ b/generators/init-product/templates/plain/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
               awsTag="latest"
               ;;
             *)
-              awsTag="${CIRCLE_BRANCH}"
+            awsTag="${CIRCLE_BRANCH//\//_}" # replace `/` with `_` in branch name
               ;;
             esac
             echo "using tag: --${awsTag}--"
@@ -87,7 +87,7 @@ jobs:
             export AWS_DEFAULT_REGION=eu-central-1
             # cleanup name by removing the _product suffix
             baseName=${CIRCLE_PROJECT_REPONAME%_product}
-            awsFamily="${baseName}-${CIRCLE_BRANCH}"
+            awsFamily="${baseName}-${CIRCLE_BRANCH//\//_}" # replace `/` with `_` in branch name
             echo "awsFamily --${awsFamily}--"
             tasksExists=$(aws --output text ecs list-task-definitions --family-prefix ${awsFamily})
             echo "existsTaskDefinition? --${tasksExists}--"

--- a/generators/init-product/templates/plain/.circleci/config.yml
+++ b/generators/init-product/templates/plain/.circleci/config.yml
@@ -59,12 +59,12 @@ jobs:
           name: Build and deploy
           command: |
             . ~/venv/bin/activate
-            case $CIRCLE_BRANCH in
+            case "${CIRCLE_BRANCH}${CIRCLE_TAG}" in
             master)
               awsTag="latest"
               ;;
             *)
-            awsTag="${CIRCLE_BRANCH//\//_}" # replace `/` with `_` in branch name
+              awsTag="${CIRCLE_BRANCH//\//_}${CIRCLE_TAG}" # replace `/` with `_` in branch name
               ;;
             esac
             echo "using tag: --${awsTag}--"


### PR DESCRIPTION

Closes phovea/generator-phovea#311

### Summary of changes

In config.yml template file for init-product replaced

 `${CIRCLE_BRANCH}` with `${CIRCLE_BRANCH //\//_}`

which replaces backslash with an underscore