### PR TITLE
Add build args for injection of env vars in Dockerfile_dev

### DIFF
--- a/generators/init-service/templates/sample_processed/deploy/docker-compose.partial.yml
+++ b/generators/init-service/templates/sample_processed/deploy/docker-compose.partial.yml
@@ -4,5 +4,12 @@ services:
     build:
       context: .
       dockerfile: deploy/Dockerfile_dev
+      args:
+        - http_proxy
+        - HTTP_PROXY
+        - https_proxy
+        - HTTPS_PROXY
+        - no_proxy
+        - NO_PROXY
     volumes:
     - .:/phovea


### PR DESCRIPTION
This allows to add environment variables at build time.

This requires `Dockerfile_dev` (in phovea/phovea_server) to have:

```
...
LABEL maintainer="contact@caleydo.org"

ARG http_proxy
ARG HTTP_PROXY
ARG https_proxy
ARG HTTPS_PROXY
ARG no_proxy
ARG NO_PROXY

WORKDIR /phovea
...
```

present. Changes in the environment will be picked up and
environment variables that are unset will not be set.

counterpart of phovea/phovea_server#111
phovea/phovea_server#110
closes phovea/generator-phovea#330