### PR TITLE
Allow arguments to be passed to npm scripts

### DIFF
--- a/generators/workspace/index.js
+++ b/generators/workspace/index.js
@@ -161,7 +161,7 @@ class Generator extends Base {
       // no pre post test tasks
       Object.keys(pkg.scripts).filter((s) => !/^(pre|post).*/g.test(s)).forEach((s) => {
         // generate scoped tasks
-        scripts[`${s}:${p}`] = `cd ${p} && npm run ${s}`;
+        scripts[`${s}:${p}`] = `cd ${p} && npm run ${s} --`; // add `--` in order to be able to pass arguments to the script
       });
       if (pkg.scripts.start) {
         // start script, generate one with the package name
@@ -265,7 +265,7 @@ class Generator extends Base {
         // no pre post test tasks
         cmds.filter((s) => toPatch.test(s)).forEach((s) => {
           // generate scoped tasks
-          let cmd = `.${path.sep}withinEnv "exec 'cd ${p} && npm run ${s}'"`;
+          let cmd = `.${path.sep}withinEnv "exec 'cd ${p} && npm run ${s}'" --`;
           if (/^(start|watch)/g.test(s)) {
             // special case for start to have the right working directory
             let fixedscript = pkg.scripts[s].replace(/__main__\.py/, p);


### PR DESCRIPTION
phovea/generator-phovea#354

Closes *list issues numbers here*

### Developer Checklist (Definition of Done)

* [ ] Descriptive title for this pull request provided (will be used for release notes later)
* [ ] All acceptance criteria from the issue are met
* [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
* [ ] Code is cleaned up and formatted
* [ ] Code documentation written
* [ ] Unit tests written
* [ ] Build is successful
* [ ] [Summary of changes](#summary-of-changes) written
* [ ] Wiki documentation written
* [ ] Assign at least one reviewer
* [ ] Assign at least one assignee
* [ ] Add type label (e.g., *bug*, *enhancement*) to this pull request
* [ ] Add next version label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)


### Summary of changes

* Appended `--` to npm scripts.
* Tested the steps as described in phovea/generator-phovea#354 and this fix works as expected.
* Added  `--` to the server scripts, i am not sure that is necessary  but it has no effect on the functionality.

### To test 
* Add a script to a plugin i.e.,` "myscript":"git"`
* `yo phovea:update` in workspace
* `npm run myscript:<plugin> -- -b my_branch`