### PR TITLE
Initialize plugin from the workspace

### DIFF
--- a/generators/_init-hybrid/index.js
+++ b/generators/_init-hybrid/index.js
@@ -38,7 +38,7 @@ class Generator extends Base {
 
   default() {
     const types = this.config.get('type').split('-');
-    this.composeWith(['phovea:_node', 'phovea:init-' + types[1], 'phovea:init-' + types[0]], {options: this.options})
+    this.composeWith(['phovea:_node', 'phovea:init-' + types[1], 'phovea:init-' + types[0]], {options: this.options, isWorkspace: this.options.isWorkspace})
   }
 
   end() {

--- a/generators/_init-web/index.js
+++ b/generators/_init-web/index.js
@@ -109,7 +109,8 @@ class Generator extends Base {
       return; // hybrid
     }
     this.composeWith('phovea:_node', {
-      options: this.options
+      options: this.options,
+      isWorkspace: this.options.isWorkspace
     });
   }
 
@@ -128,28 +129,28 @@ class Generator extends Base {
 
   writing() {
     const config = this.config.getAll();
+    this.cwd = this.options.isWorkspace ? (config.app || config.name) + '/' : '';
     patchPackageJSON.call(this, config, [], {
-      dependencies: this._generateDependencies(useDevVersion.call(this))
-    });
-    this.fs.copy(this.templatePath('_gitignore'), this.destinationPath('.gitignore'));
-    writeTemplates.call(this, config);
+      dependencies: this._generateDependencies(useDevVersion.call(this, this.cwd))
+    }, null, this.cwd);
+    this.fs.copy(this.templatePath('_gitignore'), this.destinationPath(this.cwd + '.gitignore'));
+    writeTemplates.call(this, config, null, this.cwd);
 
     // do not overwrite existing registry file
-    if (!fs.existsSync(this.destinationPath('src/phovea.ts'))) {
-      this.fs.copyTpl(this.templatePath('phovea.tmpl.ts'), this.destinationPath('src/phovea.ts'), stringifyAble(config));
+    if (!fs.existsSync(this.destinationPath(this.cwd + 'src/phovea.ts'))) {
+      this.fs.copyTpl(this.templatePath('phovea.tmpl.ts'), this.destinationPath(this.cwd + 'src/phovea.ts'), stringifyAble(config));
     }
   }
 
   install() {
-    if (this.options.install) {
-      this.installDependencies({
-        bower: false
-      });
+    if (this.options.options.install) {
+      const options = this.cwd ? {cwd: this.cwd} : {}
+      this.spawnCommand("npm", ["install"], options);
     }
   }
 
   end() {
-    if(fs.existsSync(this.destinationPath('phovea.js'))) {
+    if (fs.existsSync(this.destinationPath(this.cwd + 'phovea.js'))) {
       this.log('\r\n');
       this.log(chalk.red(`ACTION REQUIRED!`));
       this.log(chalk.default(`Please migrate the content of`), chalk.yellow(`phovea.js`), chalk.default(`to`), chalk.yellow(`/src/phovea.ts`) + chalk.default(` now!`));

--- a/generators/_node/index.js
+++ b/generators/_node/index.js
@@ -152,13 +152,31 @@ class PackageJSONGenerator extends Base {
         dot: true
       }
     };
-    this.fs.copy(this.templatePath('plain/**/*'), this.destinationPath(), includeDot);
+    this.fs.copy(this.templatePath('plain/**/*'), this.destinationPath(this.cwd), includeDot);
+  }
+
+  /**
+   * When initializing a plugin from the workspace the `.yo-rc.json` config file is saved in the workspace.
+   * Therefore copy the file into the the new created plugin subdirectory and delete it from the workspace.
+   */
+  _moveConfigFile() {
+    const currentPosition = this.destinationPath('.yo-rc.json');
+    const targetPosition = this.destinationPath(this.cwd + '.yo-rc.json');
+    if (fs.existsSync(currentPosition)) {
+      this.fs.copy(currentPosition, targetPosition);
+      this.fs.delete(currentPosition);
+    }
   }
 
   end() {
     this.spawnCommandSync('git', ['init'], {
-      cwd: this.destinationPath()
+      cwd: this.destinationPath(this.cwd)
     });
+
+    // after all the files have been written move the config file from the workspace to the plugin subdirectory
+    if (this.isWorkspace) {
+      this._moveConfigFile();
+    }
   }
 }
 

--- a/generators/init-app/index.js
+++ b/generators/init-app/index.js
@@ -34,6 +34,7 @@ class PluginGenerator extends BasePluginGenerator {
     }]).then((props) => {
       this.config.set('app', props.app);
       this.config.set('clientOnly', props.clientOnly);
+      this.config.set('cwd', props.app);
     });
   }
 
@@ -43,8 +44,9 @@ class PluginGenerator extends BasePluginGenerator {
 
   writing() {
     const config = this.config.getAll();
-    this._patchPackageJSON(config, ['main']);
-    this._writeTemplates(config, !this.options.noSamples);
+    this._mkdir(config.cwd);
+    this._patchPackageJSON(config, ['main'], null, this.cwd);
+    this._writeTemplates(config, !this.options.noSamples, this.cwd);
   }
 
   end() {

--- a/generators/init-product/index.js
+++ b/generators/init-product/index.js
@@ -23,6 +23,9 @@ function buildPossibleAdditionalPlugins(type) {
 class Generator extends Base {
 
   initializing() {
+    if (fs.existsSync(this.destinationPath('.yo-rc-workspace.json'))) {
+      throw new Error(chalk.red('Found a ".yo-rc-workspace.json" file in the current directory. Please initialize a new product in an empty directory.'));
+    }
     this.services = [];
 
     // for the update

--- a/generators/init-service/index.js
+++ b/generators/init-service/index.js
@@ -18,8 +18,9 @@ class Generator extends BasePluginGenerator {
       name: 'serviceName',
       message: 'Service Name',
       default: this.config.get('serviceName')
-    }]).then((props) => {
-      this.config.set('serviceName', props.serviceName);
+    }]).then(({serviceName}) => {
+      this.config.set('serviceName', serviceName);
+      this.config.set('cwd', serviceName);
     });
   }
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -148,16 +148,16 @@ class BaseInitPluginGenerator extends Generator {
     return fs.existsSync(this.destinationPath('.yo-rc-workspace.json'));
   }
 
-  hasConfigFile() {
+  _hasConfigFile() {
     return fs.existsSync(this.destinationPath('.yo-rc.json'));
   }
 
   /**
    * If there is both a `.yo-rc-workspace.json` and `.yo-rc.json` file in the current directory
-   * the workspace is invalid and the generator can not function properly.
+   * the workspace is invalid and the generator cannot function properly.
    */
   _isInvalidWorkspace() {
-    return this._isWorkspace() && this.hasConfigFile();
+    return this._isWorkspace() && this._hasConfigFile();
   }
 
   /**

--- a/utils/index.js
+++ b/utils/index.js
@@ -134,7 +134,7 @@ class BaseInitPluginGenerator extends Generator {
 
   initializing() {
     if (this._isInvalidWorkspace()) {
-      throw new Error(chalk.red('There must be no ".yo-rc.json" file in the workspace in order for the generator to function properly.\n'))
+      throw new Error(chalk.red('Execution failed, because a ".yo-rc.json" and ".yo-rc-workspace.json" file was found. If this directory is a workspace, please remove the ".yo-rc.json" file and try again.\n'));
     }
 
     this.composeWith(['phovea:_check-own-version', 'phovea:check-node-version']);
@@ -168,7 +168,7 @@ class BaseInitPluginGenerator extends Generator {
   _mkdir(dir) {
     if (this._isWorkspace() && this.cwd !== dir + '/') {
       this.cwd = dir + '/';
-      this.log('create directory: ' + dir);
+      this.log('Create directory: ' + dir);
       return new Promise((resolve) => fs.ensureDir(dir, resolve));
     }
   }


### PR DESCRIPTION
Closes phovea/generator-phovea#366

### Developer Checklist (Definition of Done)

* [x] Descriptive title for this pull request provided (will be used for release notes later)
* [x] All acceptance criteria from the issue are met
* [x] Branch is up-to-date with the branch to be merged with, i.e., develop
* [x] Code is cleaned up and formatted
* [ ] Code documentation written
* [ ] Unit tests written
* [x] Build is successful
* [x] [Summary of changes](#summary-of-changes) written
* [ ] Wiki documentation written
* [x] Assign at least one reviewer
* [x] Assign at least one assignee
* [x] Add type label (e.g., *bug*, *enhancement*) to this pull request
* [ ] Add next version label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)


### Summary of changes

* Added functionality to initialize a plugin from the workspace.
* Added error message in case the `init-product` generator is executed in the workspace.