### PR TITLE
Use Dockerfile from product repository to build docker images

### DIFF
--- a/generators/init-product/templates/plain/build.js
+++ b/generators/init-product/templates/plain/build.js
@@ -619,7 +619,7 @@ function getDockerfilePath(p, cwd) {
     return path.join(__dirname, `${customDockerFilePath}`);
   }
 
-  return `${cwd} /'deploy/Dockerfile'`;
+  return `${cwd}/deploy/Dockerfile`;
 }
 
 function buildDockerImage(p) {


### PR DESCRIPTION
Closes phovea/generator-phovea#385

### Summary of changes

* Added feature that checks if a `docker` directory exists in the product repository and uses the `Dockerfiles` in that directory to build the product images instead of the plugins' Dockerfiles

### To test 
* Clone an existing product, i.e., `ordino_product`
* Run yo `phovea:update` using the branch of this PR
* Resolve conflicts
* Create a ordino directory with a `web` and `server` subdirectory inside of it and a custom `Dockerfile` in each subdirectory
* Run node `build.js --serial --skipTests --noDefaultTags --useSSH`

Check if the generated images use the expected `Dockerfiles`
