### PR TITLE
Get correct max version for range versions

### DIFF
--- a/test/utils-version.test.js
+++ b/test/utils-version.test.js
@@ -264,6 +264,11 @@ describe('find max version or range version from list', () => {
     const versions = ['~4.2.0-alpha.1', '^4.2.0-rc.0', '~4.2.0-beta.1', '^4.1.0', '5.1', '~2.2.0'];
     expect(version.findMaxVersion(versions)).toBe('5.1.0');
   });
+
+  it('works if versions are all ranges', () => {
+    const versions = ['^2.9.0', '~2.8.1'];
+    expect(version.findMaxVersion(versions)).toBe('^2.9.0');
+  });
 });
 
 describe('semver-intersect works for prerelease ranges', () => {

--- a/utils/version.js
+++ b/utils/version.js
@@ -38,12 +38,12 @@ module.exports.mergeVersions = (name, versions) => {
 function findMaxVersion(versions) {
   const nonRangeVersions = versions.filter((v) => !hasRangeVersionTag(v)).map((v) => semver.prerelease(v) ? v : semver.coerce(v).version); // Filter out versions with `~` and `^`
   // Sort versions and get max. Method `semver.rcomapre()` fails when you try comparing ranges, i.e., `~2.0.0`
-  const maxNonRangeVersion = nonRangeVersions.sort(semver.rcompare)[0] || versions[versions.length - 1];
+  const maxNonRangeVersion = nonRangeVersions.sort(semver.rcompare)[0] || nonRangeVersions[nonRangeVersions.length - 1];
   if (versions.some((v) => hasRangeVersionTag(v))) {
     const maxCaretRange = findMaxCaretRange(versions); // ['^1.0.0', '^1.2.3']--> '^1.2.3'
     const maxTildeRange = findMaxTildeRange(versions); // ['~1.0.0', '~1.2.5']--> '~1.2.5'
     const maxRange = maxCaretRange && maxTildeRange ? findMaxRange(maxTildeRange, maxCaretRange) : maxTildeRange || maxCaretRange;
-    return semver.gtr(maxNonRangeVersion, maxRange) ? maxNonRangeVersion : maxRange; // check maxNonRangeVersion is greater than all the versions possible in the range.
+    return maxNonRangeVersion && semver.gtr(maxNonRangeVersion, maxRange) ? maxNonRangeVersion : maxRange; // check maxNonRangeVersion is greater than all the versions possible in the range.
   }
   return maxNonRangeVersion;
 }


### PR DESCRIPTION


Closes phovea/generator-phovea#390
### Developer Checklist (Definition of Done)

* [ ] Descriptive title for this pull request provided (will be used for release notes later)
* [x] All acceptance criteria from the issue are met
* [x] Branch is up-to-date with the branch to be merged with, i.e., develop
* [x] Code is cleaned up and formatted
* [x] Code documentation written
* [x] Unit tests written
* [x] Build is successful
* [ ] [Summary of changes](#summary-of-changes) written
* [ ] Wiki documentation written
* [x] Assign at least one reviewer
* [x] Assign at least one assignee
* [x] Add type label (e.g., *bug*, *enhancement*) to this pull request
* [x] Add next version label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)


### Summary of changes

* Fixed bug when merging versions that are all ranged versions
* Added unit test to cover the case

