### PR TITLE
Fix version number production build with `--injectVersion` flag

### DIFF
--- a/generators/workspace/templates/plain_initialize_once/config/webpack.dev.js
+++ b/generators/workspace/templates/plain_initialize_once/config/webpack.dev.js
@@ -281,7 +281,7 @@ const config = {
                     from: workspaceMetaDataFile, to: base + '/bundles/phoveaMetaData.json',
                     //generate meta data file
                     transform() {
-                        return webpackHelper.generateMetaDataFile({buildId}, resolve(__dirname, '../' + defaultApp));
+                        return webpackHelper.generateMetaDataFile(resolve(__dirname, '../' + defaultApp), {buildId});
                     }
                 },
                 //use package-lock json as buildInfo

--- a/generators/workspace/templates/plain_initialize_once/config/webpack.prod.js
+++ b/generators/workspace/templates/plain_initialize_once/config/webpack.prod.js
@@ -19,6 +19,7 @@ const envMode = process.argv.indexOf('--mode') >= 0 ? process.argv[process.argv.
 const isDev = envMode === 'development';
 //workspace constants
 const workspaceYoRcFile = require('../.yo-rc-workspace.json');
+const workspacePkg = require(base + '/package.json');
 const workspaceBuildInfoFile = base + '/package-lock.json';
 const workspaceMetaDataFile = base + '/metaData.json';
 const workspaceRegistryFile = base + '/phovea_registry.js';
@@ -232,7 +233,11 @@ const config = {
                     from: workspaceMetaDataFile, to: base + '/bundles/phoveaMetaData.json',
                     //generate meta data file
                     transform() {
-                        return webpackHelper.generateMetaDataFile({buildId}, resolve(__dirname, '../' + defaultApp));
+                        const customProperties = {
+                          buildId,
+                          version: workspacePkg.version // override app version with workspace version in product build
+                        };
+                        return webpackHelper.generateMetaDataFile(resolve(__dirname, '../' + defaultApp), customProperties);
                     }
                 },
                 //use package-lock json as buildInfo

--- a/generators/workspace/templates/plain_initialize_once/config/webpackHelper.js
+++ b/generators/workspace/templates/plain_initialize_once/config/webpackHelper.js
@@ -27,9 +27,9 @@ function resolveScreenshot(appDirectory) {
   return `data:image/png;base64,${buffer}`;
 }
 
-function appendMetaData(additionalProperties, appDirectory) {
+function generateMetaDataFile(appDirectory, customProperties) {
   const pkg = require(path.join(appDirectory,'./package.json'));
-  const manifest = Object.assign(additionalProperties, {
+  const manifest = Object.assign({
     name: pkg.name,
     displayName: pkg.displayName,
     version: pkg.version,
@@ -37,12 +37,8 @@ function appendMetaData(additionalProperties, appDirectory) {
     homepage: pkg.homepage,
     description: pkg.description,
     screenshot: resolveScreenshot(appDirectory)
-  });
+  }, customProperties);
   return JSON.stringify(manifest, null, 2);
-}
-
-function generateMetaDataFile(additionalProperties, appDirectory) {
-  return appendMetaData(additionalProperties, appDirectory);
 }
 
 module.exports = {


### PR DESCRIPTION
Closes #405

### Developer Checklist (Definition of Done)

* [x] Descriptive title for this pull request provided (will be used for release notes later)
* [x] All acceptance criteria from the issue are met
* [x] Branch is up-to-date with the branch to be merged with, i.e., develop
* [x] Code is cleaned up and formatted
* [x] Code documentation written
* [ ] Unit tests written
* [x] Build is successful
* [x] [Summary of changes](#summary-of-changes) written
* [ ] Wiki documentation written
* [x] Assign at least one reviewer
* [x] Assign at least one assignee
* [x] Add type label (e.g., *bug*, *enhancement*) to this pull request
* [x] Add next version label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)


### Summary of changes

Previously, the `--injectVersion` flag in the product build.js does not have any effect, because the version was not considered in the `generateMetaDataFile()` function.  Furthermore, the workspace version number without `--injectVersion` flag was always `0.0.1` (= default version from generator).

This PR reads the workspace package.json and overrides the version of the default app with the version from the workspace package.json.

This behavior assumes that the product build.js file inserts the correct version number to the workspace package.json (i.e., without `--injectVersion` flag = default app version, with `--injectVersion` flag = version of product package.json).

### How to test

Setup phovea generator

1. Clone the generator with this branch
2. `npm install`
3. `npm link`

Setup product

1. `git clone https://github.com/Caleydo/ordino_product -b develop`
2. `npm install`
3. `npm link generator-phovea`

Check workspace version in both cases:

* Product version: `node build.js --injectVersion --skipSaveImage --skipTests --noDefaultTags --useSSH`
* Default app version:  `node build.js --skipSaveImage --skipTests --noDefaultTags --useSSH`