### PR TITLE
Use `PHOVEA_NGINX_PORT` in nginx-default.conf

### DIFF
--- a/generators/workspace/templates/plain_initialize_once/deploy/web/nginx-default.conf
+++ b/generators/workspace/templates/plain_initialize_once/deploy/web/nginx-default.conf
@@ -18,7 +18,7 @@ map "${sent_http_etag}${sent_http_last_modified}${sent_http_cache_control}${requ
 }
 
 server {
-    listen       80;
+    listen       PHOVEA_NGINX_PORT;
     server_tokens off;
     add_header X-Content-Type-Options nosniff;
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";


### PR DESCRIPTION

### Summary of changes

Previously, the string `PHOVEA_NGINX_PORT` is replaced in the nginx Dockerfile, but no string was available in the _nginx-default.conf_. Hence, setting the environment variable `PHOVEA_NGINX_PORT` did not have any effect.

Now, after adding the string `PHOVEA_NGINX_PORT` to the _nginx-default.conf_ the `PHOVEA_NGINX_PORT=80` is used.