### PR TITLE
Use `rimraf` package instead of `rm -rf` in `preinstall` script

### DIFF
--- a/generators/workspace/templates/package.tmpl.json
+++ b/generators/workspace/templates/package.tmpl.json
@@ -14,7 +14,7 @@
     "node": ">= 12.13"
   },
   "scripts": {
-    "preinstall": "rimraf \"node_modules/!(rimraf|.bin)\" package-lock.json || exit 0",
+    "preinstall": "rimraf node_modules package-lock.json || exit 0",
     "postinstall": "npm-run-all --parallel delete-dependencies:*",
     "all:compile": "npm-run-all --parallel compile:*",
     "all:compile:watch": "npm-run-all --parallel compile:watch:*",

--- a/generators/workspace/templates/package.tmpl.json
+++ b/generators/workspace/templates/package.tmpl.json
@@ -14,7 +14,7 @@
     "node": ">= 12.13"
   },
   "scripts": {
-    "preinstall": "rm -rf node_modules && rm package-lock.json || true",
+    "preinstall": "rimraf \"node_modules/!(rimraf|.bin)\" package-lock.json || exit 0",
     "postinstall": "npm-run-all --parallel delete-dependencies:*",
     "all:compile": "npm-run-all --parallel compile:*",
     "all:compile:watch": "npm-run-all --parallel compile:watch:*",


### PR DESCRIPTION
Closes phovea/generator-phovea#404

### Developer Checklist (Definition of Done)

* [x] Descriptive title for this pull request provided (will be used for release notes later)
* [ ] All acceptance criteria from the issue are met
* [x] Branch is up-to-date with the branch to be merged with, i.e., develop
* [x] Code is cleaned up and formatted
* [ ] Code documentation written
* [ ] Unit tests written
* [x] Build is successful
* [x] [Summary of changes](#summary-of-changes) written
* [ ] Wiki documentation written
* [x] Assign at least one reviewer
* [x] Assign at least one assignee
* [x] Add type label (e.g., *bug*, *enhancement*) to this pull request
* [x] Add next version label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)


### Summary of changes
* Replaced
```diff
- "preinstall": "rm -rf node_modules && rm package-lock.json || true"
+ "preinstall": "rimraf node_modules package-lock.json || exit 0"
```
* When using `rimraf node_modules` in windows you get a warning since the package deletes itself. We could solve this if we are prepared to install `rimraf `globally.
* Replaced `|| true` (throws an error in windows) with `|| exit 0 `which works for both windows and linux.
* Tested the command both in windows and linux and the workspace installation works as expected.

### Notes
 Another windows incompatible script is:
`"build:python": "rm -rf build/source && find . -name '*.pyc' -delete && node buildPython.js && cp -r ./<%-name.toLowerCase()%> build/source/",`
Both the `rm -rf` and `cp` do not exist in windows. I do not know though if this needs to be windows compatible though.

