### PR TITLE
Switched devServer proxy order to prefer workspace over defaults

### DIFF
--- a/generators/workspace/templates/plain/config/webpack.dev.js
+++ b/generators/workspace/templates/plain/config/webpack.dev.js
@@ -124,7 +124,8 @@ const config = {
         compress: true,
         host: 'localhost',
         open: false,
-        proxy: Object.assign({
+        proxy: {
+            ...workspaceProxy,
             '/api/*': {
                 target: 'http://localhost:9000',
                 secure: false,
@@ -142,7 +143,7 @@ const config = {
                 target: 'http://localhost:9000',
                 secure: false
             }
-        }, workspaceProxy),
+        },
         client: {
           overlay: false,
         },


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

* [x] Descriptive title for this pull request provided (will be used for release notes later)
* [x] All acceptance criteria from the issue are met
* [x] Branch is up-to-date with the branch to be merged with, i.e., develop
* [x] Code is cleaned up and formatted
* [x] Code documentation written
* [] Unit tests written
* [x] Build is successful
* [x] [Summary of changes](#summary-of-changes) written
* [x] Wiki documentation written
* [x] Assign at least one reviewer
* [x] Assign at least one assignee
* [x] Add type label (e.g., *bug*, *enhancement*) to this pull request
* [x] Add next version label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)


### Summary of changes

Changes the order of dev server proxies to prefer the workspace configuration.
