### PR TITLE
[minor] setup.py ignore missing requirements.txt and use modern python

### DIFF
--- a/generators/_init-python/templates/plain/setup.py
+++ b/generators/_init-python/templates/plain/setup.py
@@ -3,90 +3,80 @@
 # Copyright (c) The Caleydo Team. All rights reserved.
 # Licensed under the new BSD license, available at http://caleydo.org/license
 ###############################################################################
-
+from datetime import datetime
+from json import load
+from pathlib import Path
 from setuptools import setup, find_packages
-from codecs import open
-from os import path
 
-here = path.abspath(path.dirname(__file__))
+here = Path(__file__).parent
+pkg = here / "package.json"
+pkg = load(pkg.open())
 
 
 def read_it(name):
-    with open(path.join(here, name), encoding='utf-8') as f:
-        return f.read()
-
-
-# read package.json information
-with open(path.join(here, 'package.json'), encoding='utf-8') as json_data:
-    import json
-
-    pkg = json.load(json_data)
+  fn = here / name
+  return fn.read_text() if os.path.exists(fn) else ""
 
 
 def packaged(*files):
-    r = {}
-    global pkg
-    r[pkg['name']] = list(files)
-    return r
+  return {pkg['name']: list(files)}
 
 
 def requirements(file):
-    return [r.strip() for r in read_it(file).strip().split('\n') if not r.startswith('-e git+https://')]
+  return [r.strip() for r in read_it(file).strip().split('\n') if not r.startswith('-e git+https://')]
 
 
 def to_version(v):
-    import datetime
-    now = datetime.datetime.utcnow()
-    return v.replace('SNAPSHOT', now.strftime('%Y%m%d-%H%M%S'))
+  return v.replace('SNAPSHOT', datetime.utcnow().strftime('%Y%m%d-%H%M%S'))
 
 
 setup(
-    name=pkg['name'].lower(),
-    version=to_version(pkg['version']),
-    url=pkg['homepage'],
-    description=pkg['description'],
-    long_description=read_it('README.md'),
-    long_description_content_type='text/markdown',
-    keywords=pkg.get('keywords', ''),
-    author=pkg['author']['name'],
-    author_email=pkg['author']['email'],
-    license=pkg['license'],
-    zip_safe=False,
+  name=pkg['name'].lower(),
+  version=to_version(pkg['version']),
+  url=pkg['homepage'],
+  description=pkg['description'],
+  long_description=read_it('README.md'),
+  long_description_content_type='text/markdown',
+  keywords=pkg.get('keywords', ''),
+  author=pkg['author']['name'],
+  author_email=pkg['author']['email'],
+  license=pkg['license'],
+  zip_safe=False,
 
-    entry_points={
-      'phovea.registry': ['{0} = {0}:phovea'.format(pkg['name'])],
-      'phovea.config': ['{0} = {0}:phovea_config'.format(pkg['name'])]
-    },
+  # entry_points={
+  #   'phovea.registry': ['{0} = {0}:phovea'.format(pkg['name'])],
+  #   'phovea.config': ['{0} = {0}:phovea_config'.format(pkg['name'])]
+  # },
 
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    classifiers=[
-      'Intended Audience :: Developers',
-      'Operating System :: OS Independent',
-      # Pick your license as you wish (should match "license" above)
-      'License :: OSI Approved :: ' + ('BSD License' if pkg['license'] == 'BSD-3-Clause' else pkg['license']),
-      'Programming Language :: Python',
-      'Programming Language :: Python :: 3.7'
-    ],
+  # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+  classifiers=[
+    'Intended Audience :: Developers',
+    'Operating System :: OS Independent',
+    # Pick your license as you wish (should match "license" above)
+    'License :: OSI Approved :: ' + ('BSD License' if pkg['license'] == 'BSD-3-Clause' else pkg['license']),
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3.8'
+  ],
 
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['docs', 'tests*']),
+  # You can just specify the packages manually here if your project is
+  # simple. Or you can use find_packages().
+  packages=find_packages(exclude=['docs', 'tests*']),
 
-    # List run-time dependencies here.  These will be installed by pip when
-    # your project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/requirements.html
-    install_requires=requirements('requirements.txt'),
-    tests_require=requirements('requirements_dev.txt'),
+  # List run-time dependencies here.  These will be installed by pip when
+  # your project is installed. For an analysis of "install_requires" vs pip's
+  # requirements files see:
+  # https://packaging.python.org/en/latest/requirements.html
+  install_requires=requirements('requirements.txt'),
+  tests_require=requirements('requirements_dev.txt'),
 
-    # If there are data files included in your packages that need to be
-    # installed, specify them here.  If using Python 2.6 or less, then these
-    # have to be included in MANIFEST.in as well.
-    package_data=packaged('config.json', 'buildInfo.json'),
+  # If there are data files included in your packages that need to be
+  # installed, specify them here.  If using Python 2.6 or less, then these
+  # have to be included in MANIFEST.in as well.
+  package_data={pkg['name']: ['config.json', 'buildInfo.json']},
 
-    # Although 'package_data' is the preferred approach, in some case you may
-    # need to place data files outside of your packages. See:
-    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
-    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=[]  # [('my_data', ['data/data_file'])],
+  # Although 'package_data' is the preferred approach, in some case you may
+  # need to place data files outside of your packages. See:
+  # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
+  # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
+  data_files=[]  # [('my_data', ['data/data_file'])],
 )

--- a/generators/_init-python/templates/plain/setup.py
+++ b/generators/_init-python/templates/plain/setup.py
@@ -6,6 +6,7 @@
 from datetime import datetime
 from json import load
 from pathlib import Path
+
 from setuptools import setup, find_packages
 
 here = Path(__file__).parent
@@ -14,69 +15,65 @@ pkg = load(pkg.open())
 
 
 def read_it(name):
-  fn = here / name
-  return fn.read_text() if os.path.exists(fn) else ""
-
-
-def packaged(*files):
-  return {pkg['name']: list(files)}
+    fn = here / name
+    return fn.read_text() if os.path.exists(fn) else ""
 
 
 def requirements(file):
-  return [r.strip() for r in read_it(file).strip().split('\n') if not r.startswith('-e git+https://')]
+    return [r.strip() for r in read_it(file).strip().split('\n') if not r.startswith('-e git+https://')]
 
 
 def to_version(v):
-  return v.replace('SNAPSHOT', datetime.utcnow().strftime('%Y%m%d-%H%M%S'))
+    return v.replace('SNAPSHOT', datetime.utcnow().strftime('%Y%m%d-%H%M%S'))
 
 
 setup(
-  name=pkg['name'].lower(),
-  version=to_version(pkg['version']),
-  url=pkg['homepage'],
-  description=pkg['description'],
-  long_description=read_it('README.md'),
-  long_description_content_type='text/markdown',
-  keywords=pkg.get('keywords', ''),
-  author=pkg['author']['name'],
-  author_email=pkg['author']['email'],
-  license=pkg['license'],
-  zip_safe=False,
+    name=pkg['name'].lower(),
+    version=to_version(pkg['version']),
+    url=pkg['homepage'],
+    description=pkg['description'],
+    long_description=read_it('README.md'),
+    long_description_content_type='text/markdown',
+    keywords=pkg.get('keywords', ''),
+    author=pkg['author']['name'],
+    author_email=pkg['author']['email'],
+    license=pkg['license'],
+    zip_safe=False,
 
-  # entry_points={
-  #   'phovea.registry': ['{0} = {0}:phovea'.format(pkg['name'])],
-  #   'phovea.config': ['{0} = {0}:phovea_config'.format(pkg['name'])]
-  # },
+    # entry_points={
+    #   'phovea.registry': ['{0} = {0}:phovea'.format(pkg['name'])],
+    #   'phovea.config': ['{0} = {0}:phovea_config'.format(pkg['name'])]
+    # },
 
-  # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-  classifiers=[
-    'Intended Audience :: Developers',
-    'Operating System :: OS Independent',
-    # Pick your license as you wish (should match "license" above)
-    'License :: OSI Approved :: ' + ('BSD License' if pkg['license'] == 'BSD-3-Clause' else pkg['license']),
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 3.8'
-  ],
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        'Intended Audience :: Developers',
+        'Operating System :: OS Independent',
+        # Pick your license as you wish (should match "license" above)
+        'License :: OSI Approved :: ' + ('BSD License' if pkg['license'] == 'BSD-3-Clause' else pkg['license']),
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.8'
+    ],
 
-  # You can just specify the packages manually here if your project is
-  # simple. Or you can use find_packages().
-  packages=find_packages(exclude=['docs', 'tests*']),
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    packages=find_packages(exclude=['docs', 'tests*']),
 
-  # List run-time dependencies here.  These will be installed by pip when
-  # your project is installed. For an analysis of "install_requires" vs pip's
-  # requirements files see:
-  # https://packaging.python.org/en/latest/requirements.html
-  install_requires=requirements('requirements.txt'),
-  tests_require=requirements('requirements_dev.txt'),
+    # List run-time dependencies here.  These will be installed by pip when
+    # your project is installed. For an analysis of "install_requires" vs pip's
+    # requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=requirements('requirements.txt'),
+    tests_require=requirements('requirements_dev.txt'),
 
-  # If there are data files included in your packages that need to be
-  # installed, specify them here.  If using Python 2.6 or less, then these
-  # have to be included in MANIFEST.in as well.
-  package_data={pkg['name']: ['config.json', 'buildInfo.json']},
+    # If there are data files included in your packages that need to be
+    # installed, specify them here.  If using Python 2.6 or less, then these
+    # have to be included in MANIFEST.in as well.
+    package_data={pkg['name']: ['config.json', 'buildInfo.json']},
 
-  # Although 'package_data' is the preferred approach, in some case you may
-  # need to place data files outside of your packages. See:
-  # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
-  # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-  data_files=[]  # [('my_data', ['data/data_file'])],
+    # Although 'package_data' is the preferred approach, in some case you may
+    # need to place data files outside of your packages. See:
+    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
+    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
+    data_files=[]  # [('my_data', ['data/data_file'])],
 )


### PR DESCRIPTION
### Summary of changes
**Functional changes:**
Treat non existing requirements files like empty ones (makes migration easier, if requirements_dev.txt don't exist) - this is annoying in fastapi

**Style changes:**
Remove codecs.open (deprecated since py2.6, default-codec is UTF-8 anyways)
Use pathlib for path stuff (introduced in py3.4)
Put imports at the top of the file (pep8: Imports are always put at the top of the file, just after any module comments and docstrings, and before module globals and constants)
No need for `global` keyword (to read a global scope var) no need for one-time-use-function