### PR TITLE
Fixed tests and added build task to all branches in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ workflows:
       - build:
           filters:
             tags:
-              ignore: /.*/
+              ignore: /^v.*/
   build-publish-tag:
     jobs:
       - build:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,5 +32,5 @@ exports.test = runTest;
 exports.testWatch = series(runTest, testWatch);
 exports.lint = lint;
 exports.lintWatch = series(lint, lintWatch);
-exports.prepublish = series(lint);
+exports.prepublish = series(lint, runTest);
 exports.default = series(lint, runTest);

--- a/test/init-app-slib.test.js
+++ b/test/init-app-slib.test.js
@@ -62,8 +62,9 @@ describe('generate app-slib plugin with prompt `app: appName` and the rest defau
     assert.jsonFileContent('package.json', {types: initWebPackage.types});
   });
 
-  it('generates `.gitignore` that has no `/dist/` entry', () => {
-    assert.noFileContent('.gitignore', '/dist/');
+  it('generates `.gitignore` that has no `/dist/` but a `/dist/tsBuildInfoFile` entry', () => {
+    assert.noFileContent('.gitignore', '/dist/\n');
+    assert.fileContent('.gitignore', '/dist/tsBuildInfoFile\n');
   });
 
   it('generates `tsconfig.json` with correct content', () => {

--- a/test/init-app.test.js
+++ b/test/init-app.test.js
@@ -61,8 +61,9 @@ describe('generate app plugin with prompt `app: appName` and the rest default pr
     assert.jsonFileContent('package.json', {types: initWebPackage.types});
   });
 
-  it('generates `.gitignore` that has no `/dist/` entry', () => {
-    assert.noFileContent('.gitignore', '/dist/');
+  it('generates `.gitignore` that has no `/dist/` but a `/dist/tsBuildInfoFile` entry', () => {
+    assert.noFileContent('.gitignore', '/dist/\n');
+    assert.fileContent('.gitignore', '/dist/tsBuildInfoFile\n');
   });
 
   it('generates `tsconfig.json` with correct content', () => {

--- a/test/init-lib-service.test.js
+++ b/test/init-lib-service.test.js
@@ -59,8 +59,9 @@ describe('generate lib-service plugin with default prompt values', () => {
     assert.jsonFileContent('package.json', {types: initWebPackage.types});
   });
 
-  it('generates `.gitignore` that has no `/dist/` entry', () => {
-    assert.noFileContent('.gitignore', '/dist/');
+  it('generates `.gitignore` that has no `/dist/` but a `/dist/tsBuildInfoFile` entry', () => {
+    assert.noFileContent('.gitignore', '/dist/\n');
+    assert.fileContent('.gitignore', '/dist/tsBuildInfoFile\n');
   });
 
   it('generates `tsconfig.json` with correct content', () => {

--- a/test/init-lib-slib.test.js
+++ b/test/init-lib-slib.test.js
@@ -58,8 +58,9 @@ describe('generate lib-slib plugin with default prompt values', () => {
     assert.jsonFileContent('package.json', {types: initWebPackage.types});
   });
 
-  it('generates `.gitignore` that has no `/dist/` entry', () => {
-    assert.noFileContent('.gitignore', '/dist/');
+  it('generates `.gitignore` that has no `/dist/` but a `/dist/tsBuildInfoFile` entry', () => {
+    assert.noFileContent('.gitignore', '/dist/\n');
+    assert.fileContent('.gitignore', '/dist/tsBuildInfoFile\n');
   });
 
   it('generates `tsconfig.json` with correct content', () => {

--- a/test/init-lib.test.js
+++ b/test/init-lib.test.js
@@ -67,8 +67,9 @@ describe('Generate lib plugin with default prompt values', () => {
     assert.jsonFileContent('package.json', {types: initWebPackage.types});
   });
 
-  it('generates `.gitignore` that has no `/dist/` entry', () => {
-    assert.noFileContent('.gitignore', '/dist/');
+  it('generates `.gitignore` that has no `/dist/` but a `/dist/tsBuildInfoFile` entry', () => {
+    assert.noFileContent('.gitignore', '/dist/\n');
+    assert.fileContent('.gitignore', '/dist/tsBuildInfoFile\n');
   });
 
   it('generates `tsconfig.json` with correct content', () => {

--- a/test/setup-workspace.test.js
+++ b/test/setup-workspace.test.js
@@ -15,7 +15,7 @@ const dependencies = require('./test-utils/generator-dependencies');
 /**
  * Directory name to run the generator
  */
-const target = '../phovea_workpsace';
+const target = '../phovea_workspace';
 
 const product = 'org/dummy_product';
 
@@ -53,8 +53,8 @@ describe('generator setup-workspace', () => {
     //     rimraf.sync(path.join(__dirname, target));
     // });
 
-    it('calls WorkspaceUtils.cloneRepo(...args) 13 times (1 product + 12 plugins)', () => {
-        expect(WorkspaceUtils.cloneRepo.mock.calls.length).toBe(13);
+    it('calls WorkspaceUtils.cloneRepo(...args) 7 times (1 product + 6 plugins defined in phovea_product_dummy.json)', () => {
+        expect(WorkspaceUtils.cloneRepo.mock.calls.length).toBe(7);
     });
 
     it('clones product by calling `WorkspaceUtils.cloneRepo(...args)` with the correct args', () => {


### PR DESCRIPTION
Closes https://github.com/phovea/generator-phovea/issues/514

### Developer Checklist (Definition of Done)

* [x] Descriptive title for this pull request provided (will be used for release notes later)
* [x] All acceptance criteria from the issue are met
* [x] Branch is up-to-date with the branch to be merged with, i.e., develop
* [x] Code is cleaned up and formatted
* [x] Code documentation written
* [x] Unit tests written
* [x] Build is successful
* [x] [Summary of changes](#summary-of-changes) written
* [ ] Wiki documentation written
* [x] Assign at least one reviewer
* [x] Assign at least one assignee
* [x] Add type label (e.g., *bug*, *enhancement*) to this pull request
* [x] Add next version label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)


### Summary of changes

* Fixed the tests to match some new workspace changes, like the removal of `phovea_[core|clue|...]` repos a long time ago, or the existance of the `/dist/tsBuildInfoFile`.
* Added the `build-only` job to run in all branches, that's how this was missed in the first place. @anita-steiner was it intended to not be run in any branches?
