### PR TITLE
Pin sass version to 1.52.1

### DIFF
--- a/generators/workspace/templates/package.tmpl.json
+++ b/generators/workspace/templates/package.tmpl.json
@@ -63,7 +63,7 @@
     "prettier": "^2.5.1",
     "raw-loader": "~4.0.2",
     "rimraf": "~3.0.2",
-    "sass": "^1.29.0",
+    "sass": "1.52.1",
     "sass-loader": "~9.0.2",
     "shx": "~0.3.3",
     "source-map-loader": "~1.1.3",


### PR DESCRIPTION
Pin sass version to 1.52.1 to fix the following error:
![image](https://user-images.githubusercontent.com/57343176/172396027-44840832-b7d8-43c3-ab42-3f4016002f92.png)
