### PR TITLE
Pin webpack-cli/serve to 1.6.1

### DIFF
--- a/generators/workspace/templates/package.tmpl.json
+++ b/generators/workspace/templates/package.tmpl.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.9.0",
     "@typescript-eslint/parser": "^5.9.0",
+    "@webpack-cli/serve": "1.6.1",
     "clean-webpack-plugin": "~3.0.0",
     "copy-webpack-plugin": "~6.3.2",
     "css-loader": "~4.3.0",


### PR DESCRIPTION
Pin webpack-cli/serve to version 1.6.1 to prevent the following error: `cli.isMultipleCompiler is not a function`