### PR TITLE
Bump version of webpack-cli@~4.10.0

### DIFF
--- a/generators/workspace/templates/package.tmpl.json
+++ b/generators/workspace/templates/package.tmpl.json
@@ -75,7 +75,7 @@
     "url-loader": "~4.1.1",
     "webpack": "~4.46.0",
     "webpack-bundle-analyzer": "~4.5.0",
-    "webpack-cli": "~4.9.2",
+    "webpack-cli": "~4.10.0",
     "webpack-dev-server": "~4.7.4"
   }
 }


### PR DESCRIPTION
Fixes webpack start error `cli.isMultipleCompilers`

See also the following webpack issues:
* https://github.com/webpack/webpack-cli/issues/3294
* https://github.com/webpack/webpack/issues/15951
